### PR TITLE
User/jni2/date time format

### DIFF
--- a/eFMUContainerManager.Core/EfmuContainerManifest.cs
+++ b/eFMUContainerManager.Core/EfmuContainerManifest.cs
@@ -82,7 +82,7 @@ namespace eFMI.ContainerManager
             this.XsdVersion = EfmuContainerManifestProperties.ContainerManifestSchemaVersion;
             this.EfmiVersion = EfmuCommonManifestProperties.EfmiVersion;
             this.Name = name;
-            DateTime dateTime = DateTime.UtcNow;
+            DateTime dateTime = DateTime.UtcNow; // UTC time is needed, because format string doesn't convert offset time.
             this.CreationDateAndTime = dateTime.ToString(EfmuCommonManifestProperties.GenerationDateAndTimeFormat);
 
             this.ValidateXmlTree = validateXmlTree;

--- a/eFMUContainerManager.Core/EfmuContainerManifest.cs
+++ b/eFMUContainerManager.Core/EfmuContainerManifest.cs
@@ -82,7 +82,7 @@ namespace eFMI.ContainerManager
             this.XsdVersion = EfmuContainerManifestProperties.ContainerManifestSchemaVersion;
             this.EfmiVersion = EfmuCommonManifestProperties.EfmiVersion;
             this.Name = name;
-            DateTime dateTime = DateTime.Now;
+            DateTime dateTime = DateTime.UtcNow;
             this.CreationDateAndTime = dateTime.ToString(EfmuCommonManifestProperties.GenerationDateAndTimeFormat);
 
             this.ValidateXmlTree = validateXmlTree;
@@ -120,7 +120,7 @@ namespace eFMI.ContainerManager
             rootElem.SetAttributeValue("name", Name);
 
             /* update creationDate set in constructor or read beforehand */
-            DateTime dateTime = DateTime.Now;
+            DateTime dateTime = DateTime.UtcNow; // UTC time is needed, because format string doesn't convert offset time.
             CreationDateAndTime = dateTime.ToString(EfmuCommonManifestProperties.GenerationDateAndTimeFormat);
             rootElem.SetAttributeValue(EfmuCommonManifestProperties.GenerationDateAndTime, CreationDateAndTime);
 

--- a/eFMUManifestsAndContainers/ManifestProperties/EfmuCommonManifestProperties.cs
+++ b/eFMUManifestsAndContainers/ManifestProperties/EfmuCommonManifestProperties.cs
@@ -24,7 +24,7 @@ namespace eFMI.ManifestsAndContainers.ManifestProperties
         /* Manifest element and other element with tool/date+time information */
         public const string GenerationTool = "generationTool";
         public const string GenerationDateAndTime = "generationDateAndTime";
-        public const string GenerationDateAndTimeFormat = "o";
+        public const string GenerationDateAndTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
 
         /* manifest file listing */
         public const string FilesElementName = "Files";


### PR DESCRIPTION
Changed date and time format for attribute generationDateAndTime to "yyyy-MM-ddTHH:mm:ssZ".