### PR TITLE
Increased Binary Code and Container manifest version numbers

### DIFF
--- a/eFMUManifestsAndContainers/ManifestProperties/EfmuBinCodeManifestProperties.cs
+++ b/eFMUManifestsAndContainers/ManifestProperties/EfmuBinCodeManifestProperties.cs
@@ -24,7 +24,7 @@ namespace eFMI.ManifestsAndContainers.ManifestProperties
         /* schema */
         public const string BinCodeManifestSchemaDirName = "BinaryCode";
         public const string BinCodeManifestSchemaFileName = "efmiBinaryCodeManifest.xsd";
-        public const string BinCodeManifestSchemaVersion = "0.11.0";
+        public const string BinCodeManifestSchemaVersion = "0.12.0";
 
         /* element/attribute names used in manifest file */
 

--- a/eFMUManifestsAndContainers/ManifestProperties/EfmuContainerManifestProperties.cs
+++ b/eFMUManifestsAndContainers/ManifestProperties/EfmuContainerManifestProperties.cs
@@ -23,7 +23,7 @@ namespace eFMI.ManifestsAndContainers.ManifestProperties
     {
         /* schema */
         public const string ContainerManifestSchemaFile = "efmiContainerManifest.xsd";
-        public const string ContainerManifestSchemaVersion = "0.9.0";
+        public const string ContainerManifestSchemaVersion = "0.10.0";
 
         /* manifest file */
         public const string ContainerManifestFileName = "__content.xml";


### PR DESCRIPTION
XSD Schema of eFMI Standard now forces proper format of 'generationDateAndTime' of manifests; this resulted in a new XSD Schema version.

The pull request updates to that very version.